### PR TITLE
Collect strategy data from metatrader 5

### DIFF
--- a/MT5_AdvancedDataCollector.mq5
+++ b/MT5_AdvancedDataCollector.mq5
@@ -1,0 +1,455 @@
+//+------------------------------------------------------------------+
+//|                                    MT5_AdvancedDataCollector.mq5 |
+//|                        Copyright 2024, MetaQuotes Software Corp. |
+//|                                             https://www.mql5.com |
+//+------------------------------------------------------------------+
+#property copyright "Copyright 2024, MetaQuotes Software Corp."
+#property link      "https://www.mql5.com"
+#property version   "2.00"
+#property script_show_inputs
+
+//--- Input parameters
+input group "=== Moving Average Settings ==="
+input int      MA_Fast_Period = 10;        // Fast Moving Average Period
+input int      MA_Slow_Period = 20;        // Slow Moving Average Period
+input int      MA_Trend_Period = 50;       // Trend Moving Average Period
+input ENUM_MA_METHOD MA_Method = MODE_EMA; // Moving Average Method
+input ENUM_APPLIED_PRICE MA_Price = PRICE_CLOSE; // Applied Price
+
+input group "=== Data Collection Settings ==="
+input int      Max_Data_Points = 5000;     // Maximum data points to collect
+input string   Output_File = "MA_Strategy_Data.csv"; // Output file name
+input bool     Collect_Crossovers = true;  // Collect MA crossover data
+input bool     Collect_Trend_Changes = true; // Collect trend change data
+input bool     Collect_Price_Action = true; // Collect price action data
+input double   Min_Price_Move = 0.0001;    // Minimum price movement
+input int      Lookback_Bars = 100;        // Bars to look back for analysis
+
+input group "=== Filter Settings ==="
+input double   Min_Volume = 100;           // Minimum volume filter
+input bool     Use_Time_Filter = false;    // Use time-based filtering
+input int      Start_Hour = 9;             // Start hour (24h format)
+input int      End_Hour = 17;              // End hour (24h format)
+
+//--- Global variables
+int ma_fast_handle, ma_slow_handle, ma_trend_handle;
+double ma_fast[], ma_slow[], ma_trend[];
+datetime time_data[];
+double open_data[], high_data[], low_data[], close_data[];
+long volume_data[];
+int data_count = 0;
+string csv_header = "Time,Open,High,Low,Close,Volume,MA_Fast,MA_Slow,MA_Trend,MA_Diff,Cross_Type,Trend_Type,Price_Action,RSI,ATR";
+
+//+------------------------------------------------------------------+
+//| Script program start function                                    |
+//+------------------------------------------------------------------+
+void OnStart()
+{
+    Print("=== MT5 Advanced Data Collector Started ===");
+    
+    // Initialize indicators
+    if(!InitializeIndicators())
+    {
+        Print("Error: Failed to initialize indicators");
+        return;
+    }
+    
+    // Collect data
+    if(!CollectMarketData())
+    {
+        Print("Error: Failed to collect market data");
+        return;
+    }
+    
+    // Save data to file
+    SaveDataToCSV();
+    
+    Print("=== Data Collection Completed ===");
+    Print("Total data points collected: ", data_count);
+    Print("Output file: ", Output_File);
+}
+
+//+------------------------------------------------------------------+
+//| Initialize all indicators                                        |
+//+------------------------------------------------------------------+
+bool InitializeIndicators()
+{
+    // Create MA handles
+    ma_fast_handle = iMA(_Symbol, _Period, MA_Fast_Period, 0, MA_Method, MA_Price);
+    ma_slow_handle = iMA(_Symbol, _Period, MA_Slow_Period, 0, MA_Method, MA_Price);
+    ma_trend_handle = iMA(_Symbol, _Period, MA_Trend_Period, 0, MA_Method, MA_Price);
+    
+    if(ma_fast_handle == INVALID_HANDLE || ma_slow_handle == INVALID_HANDLE || ma_trend_handle == INVALID_HANDLE)
+    {
+        Print("Error: Failed to create MA handles");
+        return false;
+    }
+    
+    // Set arrays as series
+    ArraySetAsSeries(ma_fast, true);
+    ArraySetAsSeries(ma_slow, true);
+    ArraySetAsSeries(ma_trend, true);
+    ArraySetAsSeries(time_data, true);
+    ArraySetAsSeries(open_data, true);
+    ArraySetAsSeries(high_data, true);
+    ArraySetAsSeries(low_data, true);
+    ArraySetAsSeries(close_data, true);
+    ArraySetAsSeries(volume_data, true);
+    
+    // Resize arrays
+    ArrayResize(ma_fast, Max_Data_Points);
+    ArrayResize(ma_slow, Max_Data_Points);
+    ArrayResize(ma_trend, Max_Data_Points);
+    ArrayResize(time_data, Max_Data_Points);
+    ArrayResize(open_data, Max_Data_Points);
+    ArrayResize(high_data, Max_Data_Points);
+    ArrayResize(low_data, Max_Data_Points);
+    ArrayResize(close_data, Max_Data_Points);
+    ArrayResize(volume_data, Max_Data_Points);
+    
+    Print("Indicators initialized successfully");
+    return true;
+}
+
+//+------------------------------------------------------------------+
+//| Collect market data based on conditions                         |
+//+------------------------------------------------------------------+
+bool CollectMarketData()
+{
+    int total_bars = Bars(_Symbol, _Period);
+    if(total_bars < MA_Trend_Period + Lookback_Bars)
+    {
+        Print("Error: Not enough historical data");
+        return false;
+    }
+    
+    // Copy indicator data
+    if(CopyBuffer(ma_fast_handle, 0, 0, Max_Data_Points, ma_fast) <= 0 ||
+       CopyBuffer(ma_slow_handle, 0, 0, Max_Data_Points, ma_slow) <= 0 ||
+       CopyBuffer(ma_trend_handle, 0, 0, Max_Data_Points, ma_trend) <= 0)
+    {
+        Print("Error: Failed to copy MA buffers");
+        return false;
+    }
+    
+    // Copy market data
+    if(CopyTime(_Symbol, _Period, 0, Max_Data_Points, time_data) <= 0 ||
+       CopyOpen(_Symbol, _Period, 0, Max_Data_Points, open_data) <= 0 ||
+       CopyHigh(_Symbol, _Period, 0, Max_Data_Points, high_data) <= 0 ||
+       CopyLow(_Symbol, _Period, 0, Max_Data_Points, low_data) <= 0 ||
+       CopyClose(_Symbol, _Period, 0, Max_Data_Points, close_data) <= 0 ||
+       CopyTickVolume(_Symbol, _Period, 0, Max_Data_Points, volume_data) <= 0)
+    {
+        Print("Error: Failed to copy market data");
+        return false;
+    }
+    
+    // Analyze and collect data
+    for(int i = MA_Trend_Period; i < Max_Data_Points && data_count < Max_Data_Points; i++)
+    {
+        if(ShouldCollectAtBar(i))
+        {
+            StoreDataPoint(i);
+        }
+    }
+    
+    return true;
+}
+
+//+------------------------------------------------------------------+
+//| Determine if data should be collected at this bar               |
+//+------------------------------------------------------------------+
+bool ShouldCollectAtBar(int index)
+{
+    if(index < 2) return false;
+    
+    // Time filter
+    if(Use_Time_Filter)
+    {
+        MqlDateTime dt;
+        TimeToStruct(time_data[index], dt);
+        if(dt.hour < Start_Hour || dt.hour > End_Hour)
+            return false;
+    }
+    
+    // Volume filter
+    if(volume_data[index] < Min_Volume)
+        return false;
+    
+    // Check for crossover conditions
+    if(Collect_Crossovers && CheckForCrossover(index))
+        return true;
+    
+    // Check for trend changes
+    if(Collect_Trend_Changes && CheckForTrendChange(index))
+        return true;
+    
+    // Check for price action
+    if(Collect_Price_Action && CheckForPriceAction(index))
+        return true;
+    
+    return false;
+}
+
+//+------------------------------------------------------------------+
+//| Check for moving average crossovers                             |
+//+------------------------------------------------------------------+
+bool CheckForCrossover(int index)
+{
+    double fast_curr = ma_fast[index];
+    double fast_prev = ma_fast[index + 1];
+    double slow_curr = ma_slow[index];
+    double slow_prev = ma_slow[index + 1];
+    
+    // Bullish crossover
+    if(fast_prev <= slow_prev && fast_curr > slow_curr)
+        return true;
+    
+    // Bearish crossover
+    if(fast_prev >= slow_prev && fast_curr < slow_curr)
+        return true;
+    
+    return false;
+}
+
+//+------------------------------------------------------------------+
+//| Check for trend changes                                         |
+//+------------------------------------------------------------------+
+bool CheckForTrendChange(int index)
+{
+    double fast_curr = ma_fast[index];
+    double slow_curr = ma_slow[index];
+    double trend_curr = ma_trend[index];
+    
+    double fast_prev = ma_fast[index + 1];
+    double slow_prev = ma_slow[index + 1];
+    double trend_prev = ma_trend[index + 1];
+    
+    // Check if trend direction changed
+    bool current_bullish = (fast_curr > slow_curr) && (slow_curr > trend_curr);
+    bool previous_bullish = (fast_prev > slow_prev) && (slow_prev > trend_prev);
+    
+    return (current_bullish != previous_bullish);
+}
+
+//+------------------------------------------------------------------+
+//| Check for significant price action                               |
+//+------------------------------------------------------------------+
+bool CheckForPriceAction(int index)
+{
+    double price_change = MathAbs(close_data[index] - close_data[index + 1]);
+    double price_range = high_data[index] - low_data[index];
+    
+    // Check for significant price movement
+    if(price_change >= Min_Price_Move)
+        return true;
+    
+    // Check for high volatility
+    if(price_range >= (close_data[index] * 0.01)) // 1% range
+        return true;
+    
+    return false;
+}
+
+//+------------------------------------------------------------------+
+//| Store data point                                                 |
+//+------------------------------------------------------------------+
+void StoreDataPoint(int index)
+{
+    if(data_count >= Max_Data_Points) return;
+    
+    data_count++;
+    
+    // Print progress
+    if(data_count % 500 == 0)
+    {
+        Print("Collected ", data_count, " data points...");
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Get crossover type                                               |
+//+------------------------------------------------------------------+
+string GetCrossoverType(int index)
+{
+    if(index < 1) return "NONE";
+    
+    double fast_curr = ma_fast[index];
+    double fast_prev = ma_fast[index + 1];
+    double slow_curr = ma_slow[index];
+    double slow_prev = ma_slow[index + 1];
+    
+    if(fast_prev <= slow_prev && fast_curr > slow_curr)
+        return "BULLISH";
+    else if(fast_prev >= slow_prev && fast_curr < slow_curr)
+        return "BEARISH";
+    else
+        return "NONE";
+}
+
+//+------------------------------------------------------------------+
+//| Get trend type                                                   |
+//+------------------------------------------------------------------+
+string GetTrendType(int index)
+{
+    double fast = ma_fast[index];
+    double slow = ma_slow[index];
+    double trend = ma_trend[index];
+    
+    if(fast > slow && slow > trend)
+        return "STRONG_BULL";
+    else if(fast > slow)
+        return "BULL";
+    else if(fast < slow && slow < trend)
+        return "STRONG_BEAR";
+    else if(fast < slow)
+        return "BEAR";
+    else
+        return "NEUTRAL";
+}
+
+//+------------------------------------------------------------------+
+//| Get price action type                                            |
+//+------------------------------------------------------------------+
+string GetPriceActionType(int index)
+{
+    if(index < 1) return "NONE";
+    
+    double open = open_data[index];
+    double close = close_data[index];
+    double high = high_data[index];
+    double low = low_data[index];
+    
+    double body_size = MathAbs(close - open);
+    double total_range = high - low;
+    
+    if(body_size > (total_range * 0.7))
+    {
+        if(close > open)
+            return "STRONG_BULL";
+        else
+            return "STRONG_BEAR";
+    }
+    else if(body_size < (total_range * 0.3))
+    {
+        return "DOJI";
+    }
+    else
+    {
+        if(close > open)
+            return "BULL";
+        else
+            return "BEAR";
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Calculate RSI for the bar                                        |
+//+------------------------------------------------------------------+
+double CalculateRSI(int index)
+{
+    int rsi_handle = iRSI(_Symbol, _Period, 14, PRICE_CLOSE);
+    if(rsi_handle == INVALID_HANDLE) return 0;
+    
+    double rsi_buffer[];
+    ArraySetAsSeries(rsi_buffer, true);
+    
+    if(CopyBuffer(rsi_handle, 0, index, 1, rsi_buffer) > 0)
+    {
+        IndicatorRelease(rsi_handle);
+        return rsi_buffer[0];
+    }
+    
+    IndicatorRelease(rsi_handle);
+    return 0;
+}
+
+//+------------------------------------------------------------------+
+//| Calculate ATR for the bar                                        |
+//+------------------------------------------------------------------+
+double CalculateATR(int index)
+{
+    int atr_handle = iATR(_Symbol, _Period, 14);
+    if(atr_handle == INVALID_HANDLE) return 0;
+    
+    double atr_buffer[];
+    ArraySetAsSeries(atr_buffer, true);
+    
+    if(CopyBuffer(atr_handle, 0, index, 1, atr_buffer) > 0)
+    {
+        IndicatorRelease(atr_handle);
+        return atr_buffer[0];
+    }
+    
+    IndicatorRelease(atr_handle);
+    return 0;
+}
+
+//+------------------------------------------------------------------+
+//| Save data to CSV file                                            |
+//+------------------------------------------------------------------+
+void SaveDataToCSV()
+{
+    int file_handle = FileOpen(Output_File, FILE_WRITE | FILE_CSV);
+    if(file_handle == INVALID_HANDLE)
+    {
+        Print("Error: Failed to create file ", Output_File);
+        return;
+    }
+    
+    // Write header
+    FileWrite(file_handle, csv_header);
+    
+    // Write data
+    for(int i = 0; i < data_count; i++)
+    {
+        int bar_index = i + MA_Trend_Period; // Adjust for the starting index
+        
+        if(bar_index < Max_Data_Points)
+        {
+            double ma_diff = ma_fast[bar_index] - ma_slow[bar_index];
+            string cross_type = GetCrossoverType(bar_index);
+            string trend_type = GetTrendType(bar_index);
+            string price_action = GetPriceActionType(bar_index);
+            double rsi = CalculateRSI(bar_index);
+            double atr = CalculateATR(bar_index);
+            
+            FileWrite(file_handle,
+                TimeToString(time_data[bar_index], TIME_DATE | TIME_MINUTES),
+                DoubleToString(open_data[bar_index], _Digits),
+                DoubleToString(high_data[bar_index], _Digits),
+                DoubleToString(low_data[bar_index], _Digits),
+                DoubleToString(close_data[bar_index], _Digits),
+                IntegerToString(volume_data[bar_index]),
+                DoubleToString(ma_fast[bar_index], _Digits),
+                DoubleToString(ma_slow[bar_index], _Digits),
+                DoubleToString(ma_trend[bar_index], _Digits),
+                DoubleToString(ma_diff, _Digits),
+                cross_type,
+                trend_type,
+                price_action,
+                DoubleToString(rsi, 2),
+                DoubleToString(atr, _Digits)
+            );
+        }
+    }
+    
+    FileClose(file_handle);
+    Print("Data saved to: ", Output_File);
+}
+
+//+------------------------------------------------------------------+
+//| Script deinitialization function                               |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+{
+    // Release handles
+    if(ma_fast_handle != INVALID_HANDLE)
+        IndicatorRelease(ma_fast_handle);
+    if(ma_slow_handle != INVALID_HANDLE)
+        IndicatorRelease(ma_slow_handle);
+    if(ma_trend_handle != INVALID_HANDLE)
+        IndicatorRelease(ma_trend_handle);
+    
+    Print("Advanced Data Collector script deinitialized");
+}

--- a/MT5_DataCollector.mq5
+++ b/MT5_DataCollector.mq5
@@ -1,0 +1,300 @@
+//+------------------------------------------------------------------+
+//|                                           MT5_DataCollector.mq5 |
+//|                        Copyright 2024, MetaQuotes Software Corp. |
+//|                                             https://www.mql5.com |
+//+------------------------------------------------------------------+
+#property copyright "Copyright 2024, MetaQuotes Software Corp."
+#property link      "https://www.mql5.com"
+#property version   "1.00"
+#property script_show_inputs
+
+//--- Input parameters
+input int      MA_Period_1 = 20;           // First Moving Average Period
+input int      MA_Period_2 = 50;           // Second Moving Average Period
+input ENUM_MA_METHOD MA_Method = MODE_SMA; // Moving Average Method
+input ENUM_APPLIED_PRICE MA_Price = PRICE_CLOSE; // Applied Price
+input int      Data_Collection_Points = 1000; // Number of data points to collect
+input string   File_Name = "MA_Data.csv";  // Output file name
+input bool     Collect_On_Cross = true;    // Collect data on MA crossovers
+input bool     Collect_On_Trend = true;    // Collect data on trend changes
+input double   Min_Price_Distance = 0.001; // Minimum price distance for collection
+
+//--- Global variables
+int ma_handle_1, ma_handle_2;
+double ma_buffer_1[], ma_buffer_2[];
+datetime time_buffer[];
+double price_buffer[];
+int data_count = 0;
+string csv_header = "Time,Open,High,Low,Close,Volume,MA1,MA2,MA_Diff,MA_Cross,MA_Trend";
+
+//+------------------------------------------------------------------+
+//| Script program start function                                    |
+//+------------------------------------------------------------------+
+void OnStart()
+{
+    // Initialize moving average handles
+    ma_handle_1 = iMA(_Symbol, _Period, MA_Period_1, 0, MA_Method, MA_Price);
+    ma_handle_2 = iMA(_Symbol, _Period, MA_Period_2, 0, MA_Method, MA_Price);
+    
+    if(ma_handle_1 == INVALID_HANDLE || ma_handle_2 == INVALID_HANDLE)
+    {
+        Print("Error: Failed to create MA handles");
+        return;
+    }
+    
+    // Set array as series
+    ArraySetAsSeries(ma_buffer_1, true);
+    ArraySetAsSeries(ma_buffer_2, true);
+    ArraySetAsSeries(time_buffer, true);
+    ArraySetAsSeries(price_buffer, true);
+    
+    // Initialize arrays
+    ArrayResize(ma_buffer_1, Data_Collection_Points);
+    ArrayResize(ma_buffer_2, Data_Collection_Points);
+    ArrayResize(time_buffer, Data_Collection_Points);
+    ArrayResize(price_buffer, Data_Collection_Points);
+    
+    Print("Starting data collection...");
+    Print("Symbol: ", _Symbol, " Period: ", _Period);
+    Print("MA1 Period: ", MA_Period_1, " MA2 Period: ", MA_Period_2);
+    
+    // Collect data
+    CollectData();
+    
+    // Save data to file
+    SaveDataToFile();
+    
+    Print("Data collection completed. Total points collected: ", data_count);
+}
+
+//+------------------------------------------------------------------+
+//| Collect data based on moving average conditions                 |
+//+------------------------------------------------------------------+
+void CollectData()
+{
+    int total_bars = Bars(_Symbol, _Period);
+    if(total_bars < MA_Period_2 + 10)
+    {
+        Print("Error: Not enough bars for analysis");
+        return;
+    }
+    
+    // Copy MA data
+    if(CopyBuffer(ma_handle_1, 0, 0, Data_Collection_Points, ma_buffer_1) <= 0 ||
+       CopyBuffer(ma_handle_2, 0, 0, Data_Collection_Points, ma_buffer_2) <= 0)
+    {
+        Print("Error: Failed to copy MA buffers");
+        return;
+    }
+    
+    // Copy time data
+    if(CopyTime(_Symbol, _Period, 0, Data_Collection_Points, time_buffer) <= 0)
+    {
+        Print("Error: Failed to copy time buffer");
+        return;
+    }
+    
+    // Copy close prices
+    if(CopyClose(_Symbol, _Period, 0, Data_Collection_Points, price_buffer) <= 0)
+    {
+        Print("Error: Failed to copy price buffer");
+        return;
+    }
+    
+    // Analyze data for collection conditions
+    for(int i = MA_Period_2; i < Data_Collection_Points && data_count < Data_Collection_Points; i++)
+    {
+        if(ShouldCollectData(i))
+        {
+            // Store the data point
+            StoreDataPoint(i);
+        }
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Determine if data should be collected at this point            |
+//+------------------------------------------------------------------+
+bool ShouldCollectData(int index)
+{
+    if(index < 1) return false;
+    
+    double ma1_current = ma_buffer_1[index];
+    double ma1_previous = ma_buffer_1[index + 1];
+    double ma2_current = ma_buffer_2[index];
+    double ma2_previous = ma_buffer_2[index + 1];
+    
+    // Check for MA crossover
+    if(Collect_On_Cross)
+    {
+        // Bullish crossover: MA1 crosses above MA2
+        if(ma1_previous <= ma2_previous && ma1_current > ma2_current)
+        {
+            return true;
+        }
+        // Bearish crossover: MA1 crosses below MA2
+        if(ma1_previous >= ma2_previous && ma1_current < ma2_current)
+        {
+            return true;
+        }
+    }
+    
+    // Check for trend changes
+    if(Collect_On_Trend)
+    {
+        // Check if price distance from MA is significant
+        double price_distance = MathAbs(price_buffer[index] - ma1_current);
+        if(price_distance >= Min_Price_Distance)
+        {
+            // Check for trend continuation or reversal
+            bool current_bullish = ma1_current > ma2_current;
+            bool previous_bullish = ma1_previous > ma2_previous;
+            
+            if(current_bullish != previous_bullish)
+            {
+                return true;
+            }
+        }
+    }
+    
+    return false;
+}
+
+//+------------------------------------------------------------------+
+//| Store data point for analysis                                   |
+//+------------------------------------------------------------------+
+void StoreDataPoint(int index)
+{
+    if(data_count >= Data_Collection_Points) return;
+    
+    // Get OHLCV data for this bar
+    MqlRates rates[];
+    if(CopyRates(_Symbol, _Period, index, 1, rates) <= 0)
+    {
+        Print("Error: Failed to copy rates for index ", index);
+        return;
+    }
+    
+    // Calculate additional metrics
+    double ma_diff = ma_buffer_1[index] - ma_buffer_2[index];
+    string ma_cross = GetMACrossType(index);
+    string ma_trend = GetMATrend(index);
+    
+    // Store in arrays (we'll write to file later)
+    time_buffer[data_count] = time_buffer[index];
+    price_buffer[data_count] = price_buffer[index];
+    
+    data_count++;
+    
+    // Print progress
+    if(data_count % 100 == 0)
+    {
+        Print("Collected ", data_count, " data points...");
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Get MA cross type                                               |
+//+------------------------------------------------------------------+
+string GetMACrossType(int index)
+{
+    if(index < 1) return "NONE";
+    
+    double ma1_current = ma_buffer_1[index];
+    double ma1_previous = ma_buffer_1[index + 1];
+    double ma2_current = ma_buffer_2[index];
+    double ma2_previous = ma_buffer_2[index + 1];
+    
+    if(ma1_previous <= ma2_previous && ma1_current > ma2_current)
+        return "BULLISH";
+    else if(ma1_previous >= ma2_previous && ma1_current < ma2_current)
+        return "BEARISH";
+    else
+        return "NONE";
+}
+
+//+------------------------------------------------------------------+
+//| Get MA trend                                                    |
+//+------------------------------------------------------------------+
+string GetMATrend(int index)
+{
+    double ma1_current = ma_buffer_1[index];
+    double ma2_current = ma_buffer_2[index];
+    
+    if(ma1_current > ma2_current)
+        return "BULLISH";
+    else if(ma1_current < ma2_current)
+        return "BEARISH";
+    else
+        return "NEUTRAL";
+}
+
+//+------------------------------------------------------------------+
+//| Save collected data to CSV file                                |
+//+------------------------------------------------------------------+
+void SaveDataToFile()
+{
+    int file_handle = FileOpen(File_Name, FILE_WRITE | FILE_CSV);
+    if(file_handle == INVALID_HANDLE)
+    {
+        Print("Error: Failed to create file ", File_Name);
+        return;
+    }
+    
+    // Write header
+    FileWrite(file_handle, csv_header);
+    
+    // Write data
+    for(int i = 0; i < data_count; i++)
+    {
+        // Get OHLCV data for this timestamp
+        MqlRates rates[];
+        datetime target_time = time_buffer[i];
+        
+        // Find the bar with this timestamp
+        int bar_index = iBarShift(_Symbol, _Period, target_time);
+        if(bar_index >= 0)
+        {
+            if(CopyRates(_Symbol, _Period, bar_index, 1, rates) > 0)
+            {
+                double ma1_val = ma_buffer_1[i];
+                double ma2_val = ma_buffer_2[i];
+                double ma_diff = ma1_val - ma2_val;
+                string ma_cross = GetMACrossType(i);
+                string ma_trend = GetMATrend(i);
+                
+                // Write CSV line
+                FileWrite(file_handle, 
+                    TimeToString(target_time, TIME_DATE | TIME_MINUTES),
+                    DoubleToString(rates[0].open, _Digits),
+                    DoubleToString(rates[0].high, _Digits),
+                    DoubleToString(rates[0].low, _Digits),
+                    DoubleToString(rates[0].close, _Digits),
+                    IntegerToString(rates[0].tick_volume),
+                    DoubleToString(ma1_val, _Digits),
+                    DoubleToString(ma2_val, _Digits),
+                    DoubleToString(ma_diff, _Digits),
+                    ma_cross,
+                    ma_trend
+                );
+            }
+        }
+    }
+    
+    FileClose(file_handle);
+    Print("Data saved to file: ", File_Name);
+}
+
+//+------------------------------------------------------------------+
+//| Script deinitialization function                               |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+{
+    // Release MA handles
+    if(ma_handle_1 != INVALID_HANDLE)
+        IndicatorRelease(ma_handle_1);
+    if(ma_handle_2 != INVALID_HANDLE)
+        IndicatorRelease(ma_handle_2);
+    
+    Print("MT5 Data Collector script deinitialized");
+}

--- a/MT5_DataCollector_Config.txt
+++ b/MT5_DataCollector_Config.txt
@@ -1,0 +1,95 @@
+# MT5 Data Collector Configuration Guide
+
+## Basic Script (MT5_DataCollector.mq5)
+This script collects data based on simple moving average conditions.
+
+### Key Features:
+- Two moving averages (fast and slow)
+- Crossover detection
+- Trend change detection
+- CSV output with OHLCV data
+- Customizable parameters
+
+### Input Parameters:
+- MA_Period_1: First MA period (default: 20)
+- MA_Period_2: Second MA period (default: 50)
+- MA_Method: MA calculation method (SMA, EMA, etc.)
+- MA_Price: Applied price (Close, Open, etc.)
+- Data_Collection_Points: Maximum data points to collect
+- File_Name: Output CSV filename
+- Collect_On_Cross: Enable crossover collection
+- Collect_On_Trend: Enable trend change collection
+- Min_Price_Distance: Minimum price distance for collection
+
+## Advanced Script (MT5_AdvancedDataCollector.mq5)
+This script provides more sophisticated data collection with multiple indicators.
+
+### Key Features:
+- Three moving averages (fast, slow, trend)
+- Multiple collection conditions
+- Time and volume filtering
+- RSI and ATR calculations
+- Price action analysis
+- Enhanced CSV output
+
+### Input Parameters:
+- MA_Fast_Period: Fast MA period (default: 10)
+- MA_Slow_Period: Slow MA period (default: 20)
+- MA_Trend_Period: Trend MA period (default: 50)
+- Max_Data_Points: Maximum data points (default: 5000)
+- Output_File: Output filename
+- Collect_Crossovers: Enable crossover collection
+- Collect_Trend_Changes: Enable trend change collection
+- Collect_Price_Action: Enable price action collection
+- Min_Volume: Minimum volume filter
+- Use_Time_Filter: Enable time-based filtering
+- Start_Hour/End_Hour: Time filter range
+
+## Usage Instructions:
+
+1. Copy the .mq5 files to your MetaTrader 5 Scripts folder
+2. Compile the scripts in MetaEditor
+3. Run the script on your desired chart
+4. Configure the input parameters as needed
+5. The script will create a CSV file with collected data
+
+## Output CSV Format:
+- Time: Bar timestamp
+- Open, High, Low, Close: OHLC prices
+- Volume: Tick volume
+- MA_Fast, MA_Slow, MA_Trend: Moving average values
+- MA_Diff: Difference between fast and slow MA
+- Cross_Type: Type of crossover (BULLISH/BEARISH/NONE)
+- Trend_Type: Current trend (BULL/BEAR/NEUTRAL)
+- Price_Action: Price action type
+- RSI: Relative Strength Index
+- ATR: Average True Range
+
+## Strategy Examples:
+
+### Golden Cross Strategy:
+- MA_Period_1: 50 (slow MA)
+- MA_Period_2: 200 (very slow MA)
+- Collect_On_Cross: true
+- Collect_On_Trend: true
+
+### Scalping Strategy:
+- MA_Fast_Period: 5
+- MA_Slow_Period: 10
+- MA_Trend_Period: 20
+- Min_Price_Move: 0.0001
+- Use_Time_Filter: true
+- Start_Hour: 9, End_Hour: 17
+
+### Trend Following Strategy:
+- MA_Fast_Period: 20
+- MA_Slow_Period: 50
+- MA_Trend_Period: 100
+- Collect_Trend_Changes: true
+- Collect_Price_Action: true
+
+## Notes:
+- Ensure you have sufficient historical data
+- Adjust parameters based on your trading strategy
+- Monitor the output file size for large datasets
+- Use appropriate timeframes for your strategy

--- a/README_MT5_DataCollector.md
+++ b/README_MT5_DataCollector.md
@@ -1,0 +1,177 @@
+# MetaTrader 5 Data Collection Scripts
+
+This repository contains MetaTrader 5 scripts designed for collecting market data based on moving average conditions and trading strategies.
+
+## 📁 Files Included
+
+- `MT5_DataCollector.mq5` - Basic data collection script
+- `MT5_AdvancedDataCollector.mq5` - Advanced data collection with multiple indicators
+- `MT5_DataCollector_Config.txt` - Configuration guide and usage instructions
+
+## 🚀 Quick Start
+
+### 1. Installation
+1. Copy the `.mq5` files to your MetaTrader 5 `Scripts` folder
+2. Open MetaEditor and compile the scripts
+3. Run the script on your desired chart
+
+### 2. Basic Usage
+```mql5
+// Run the basic script with default settings
+// This will collect data when MA crossovers occur
+```
+
+### 3. Advanced Usage
+```mql5
+// Configure the advanced script for your strategy
+// Set MA periods, collection conditions, and filters
+```
+
+## 📊 Features
+
+### Basic Script Features:
+- ✅ Two moving average crossover detection
+- ✅ Trend change identification
+- ✅ OHLCV data collection
+- ✅ CSV file output
+- ✅ Customizable parameters
+
+### Advanced Script Features:
+- ✅ Three moving average system (fast, slow, trend)
+- ✅ Multiple collection conditions
+- ✅ Time and volume filtering
+- ✅ RSI and ATR calculations
+- ✅ Price action analysis
+- ✅ Enhanced data output
+
+## 🎯 Strategy Examples
+
+### Golden Cross Strategy
+```mql5
+MA_Period_1 = 50
+MA_Period_2 = 200
+Collect_On_Cross = true
+Collect_On_Trend = true
+```
+
+### Scalping Strategy
+```mql5
+MA_Fast_Period = 5
+MA_Slow_Period = 10
+MA_Trend_Period = 20
+Min_Price_Move = 0.0001
+Use_Time_Filter = true
+```
+
+### Trend Following Strategy
+```mql5
+MA_Fast_Period = 20
+MA_Slow_Period = 50
+MA_Trend_Period = 100
+Collect_Trend_Changes = true
+Collect_Price_Action = true
+```
+
+## 📈 Output Data Format
+
+The scripts generate CSV files with the following columns:
+
+| Column | Description |
+|--------|-------------|
+| Time | Bar timestamp |
+| Open, High, Low, Close | OHLC prices |
+| Volume | Tick volume |
+| MA_Fast, MA_Slow, MA_Trend | Moving average values |
+| MA_Diff | Difference between fast and slow MA |
+| Cross_Type | Crossover type (BULLISH/BEARISH/NONE) |
+| Trend_Type | Current trend (BULL/BEAR/NEUTRAL) |
+| Price_Action | Price action classification |
+| RSI | Relative Strength Index |
+| ATR | Average True Range |
+
+## ⚙️ Configuration
+
+### Input Parameters
+
+#### Basic Script:
+- `MA_Period_1`: First moving average period
+- `MA_Period_2`: Second moving average period
+- `MA_Method`: MA calculation method (SMA, EMA, etc.)
+- `Data_Collection_Points`: Maximum data points to collect
+- `File_Name`: Output CSV filename
+- `Collect_On_Cross`: Enable crossover collection
+- `Collect_On_Trend`: Enable trend change collection
+
+#### Advanced Script:
+- `MA_Fast_Period`: Fast MA period
+- `MA_Slow_Period`: Slow MA period
+- `MA_Trend_Period`: Trend MA period
+- `Max_Data_Points`: Maximum data points
+- `Collect_Crossovers`: Enable crossover collection
+- `Collect_Trend_Changes`: Enable trend change collection
+- `Collect_Price_Action`: Enable price action collection
+- `Min_Volume`: Minimum volume filter
+- `Use_Time_Filter`: Enable time-based filtering
+
+## 🔧 Customization
+
+### Adding New Conditions
+You can modify the `ShouldCollectData()` or `ShouldCollectAtBar()` functions to add your own collection conditions:
+
+```mql5
+bool ShouldCollectData(int index)
+{
+    // Add your custom conditions here
+    if(YourCustomCondition(index))
+        return true;
+    
+    // Existing conditions...
+    return false;
+}
+```
+
+### Adding New Indicators
+To add new indicators, create handles and copy buffers:
+
+```mql5
+int rsi_handle = iRSI(_Symbol, _Period, 14, PRICE_CLOSE);
+double rsi_buffer[];
+CopyBuffer(rsi_handle, 0, 0, Max_Data_Points, rsi_buffer);
+```
+
+## 📝 Usage Tips
+
+1. **Data Requirements**: Ensure you have sufficient historical data for your MA periods
+2. **File Size**: Monitor output file size for large datasets
+3. **Timeframes**: Choose appropriate timeframes for your strategy
+4. **Parameters**: Adjust parameters based on your trading strategy
+5. **Testing**: Test with small datasets first
+
+## 🐛 Troubleshooting
+
+### Common Issues:
+- **"Not enough bars"**: Increase historical data or reduce MA periods
+- **"Failed to create file"**: Check file permissions and disk space
+- **"Invalid handle"**: Ensure indicators are properly initialized
+
+### Solutions:
+- Use longer timeframes for more historical data
+- Check file path and permissions
+- Verify indicator parameters are correct
+
+## 📞 Support
+
+For issues or questions:
+1. Check the configuration guide
+2. Verify your MT5 setup
+3. Test with default parameters first
+4. Review the script logs for error messages
+
+## 🔄 Updates
+
+- Version 1.0: Basic data collection script
+- Version 2.0: Advanced script with multiple indicators and filters
+
+## 📄 License
+
+This project is provided as-is for educational and research purposes. Use at your own risk.


### PR DESCRIPTION
Add MetaTrader 5 scripts for data collection based on moving average strategies, including basic and advanced versions, and comprehensive documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-8870d9b8-5b0f-4c71-80f5-fc7f42c8669e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8870d9b8-5b0f-4c71-80f5-fc7f42c8669e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

